### PR TITLE
Persist the audio player across route changes

### DIFF
--- a/src/components/files/Listing.vue
+++ b/src/components/files/Listing.vue
@@ -10,7 +10,6 @@
          :class="user.viewMode"
          @dragenter="dragEnter"
          @dragend="dragEnd">
-        <audio-player v-show="req.numDirs>0"></audio-player>
         <div>
             <div class="item header">
                 <div></div>
@@ -96,11 +95,10 @@
   import css from '@/utils/css'
   import * as api from '@/utils/api'
   import buttons from '@/utils/buttons'
-  import AudioPlayer from './AudioPlayer'
 
   export default {
     name: 'listing',
-    components: {Item, AudioPlayer},
+    components: {Item},
     data: function () {
       return {
         show: 50

--- a/src/views/Layout.vue
+++ b/src/views/Layout.vue
@@ -9,6 +9,7 @@
       <router-view @css="$emit('update:css')"></router-view>
     </main>
     <prompts></prompts>
+    <audio-player></audio-player>
   </div>
 </template>
 
@@ -17,6 +18,7 @@ import Search from '@/components/Search'
 import Sidebar from '@/components/Sidebar'
 import Prompts from '@/components/prompts/Prompts'
 import SiteHeader from '@/components/Header'
+import AudioPlayer from '@/components/files/AudioPlayer'
 
 export default {
   name: 'layout',
@@ -24,7 +26,8 @@ export default {
     Search,
     Sidebar,
     SiteHeader,
-    Prompts
+    Prompts,
+    AudioPlayer,
   },
   watch: {
     '$route': function () {


### PR DESCRIPTION
Simply raise the component up into the Layout component, then it won't be destroyed when routes changes.

Because the router matches all routes except /login to a Layout component, and then match individual routes to children of the Layout, changing a route won't cause the Layout component to be recreated (except during login/logout).